### PR TITLE
Changed Packer to Ignore MimeType if it's not a PNG or JPG file

### DIFF
--- a/glTFglbconverter/Packer.cs
+++ b/glTFglbconverter/Packer.cs
@@ -93,22 +93,21 @@ namespace glTFglbConverter
 
         private static Image.MimeTypeEnum? GetMimeType(string uri)
         {
-            if (String.IsNullOrEmpty(uri))
+            if (!String.IsNullOrEmpty(uri))
             {
-                return null;
+                if (uri.StartsWith("data:image/png;base64,") || uri.EndsWith(".png"))
+                {
+                    return Image.MimeTypeEnum.image_png;
+                }
+                else if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg") || uri.EndsWith(".jpeg"))
+                {
+                    return Image.MimeTypeEnum.image_jpeg;
+                }
             }
 
-            if (uri.StartsWith("data:image/png;base64,") || uri.EndsWith(".png"))
-            {
-                return Image.MimeTypeEnum.image_png;
-            }
+            return null;
 
-            if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg") || uri.EndsWith(".jpeg"))
-            {
-                return Image.MimeTypeEnum.image_jpeg;
-            }
-
-            throw new InvalidOperationException("Unable to determine mime type from uri");
+            //throw new InvalidOperationException("Unable to determine mime type from uri");
         }
 
         private static string GetUniqueFilePath(string directoryPath, string baseFileName, string fileExtension)


### PR DESCRIPTION
Currently the glTF -> glb converter will throw an exception for images that are not PNG or JPG due to it not being able to set the Image's MimeType.

The MimeType field of Image doesn't need to be filled with anything, as far as I know, so I removed the exception and just have it returning "null" for all images that are not PNG or JPG.